### PR TITLE
Change Plex `wake_lock_size` priority

### DIFF
--- a/custom_components/androidtv/androidtv/basetv.py
+++ b/custom_components/androidtv/androidtv/basetv.py
@@ -25,8 +25,8 @@ class BaseTV(object):
                                 'com.ellation.vrv': ['audio_state'],
                                 'com.hulu.plus': [{'playing': {'wake_lock_size' : 4}},
                                                   {'paused': {'wake_lock_size': 2}}],
-                                'com.plexapp.android': [{'playing': {'media_session_state': 3, 'wake_lock_size': 3}},
-                                                        {'paused': {'media_session_state': 3, 'wake_lock_size': 1}},
+                                'com.plexapp.android': [{'paused': {'media_session_state': 3, 'wake_lock_size': 1}},
+                                                        {'playing': {'media_session_state': 3}},
                                                         'standby']}
 
     The keys are app IDs, and the values are lists of rules that are evaluated in order.


### PR DESCRIPTION
While testing Plex, I found HA was reporting a `standby` state every 15-30 minutes before quickly correcting back to `playing`. This causes my lights to flash on and off which isn't ideal during a movie.

I'm using a 2017 Nvidia Shield device with the `c6dbc683eb71676baf16ae6125226304d428b889` on `master`. But this has been going on for a few weeks now. I can't really pinpoint a date though..

I set up the logging to report the states of the Shield every 1 second and managed to capture some extra states that I would consider `playing`, but the code considers standby.

Here are some of those log line snippets. ('wake_lock_size' = `3`, `4`, `5`, and `7`)
All of those `wake_lock_size` were while the device was `playing`. 

```
2019-10-19 20:28:10 INFO (SyncWorker_12) [custom_components.androidtv.media_player] Output of command 'GET_PROPERTIES' from 'media_player.shield': {'screen_on': True, 'awake': True, 'audio_state': 'paused', 'wake_lock_size': 3, 'current_app': 'com.plexapp.android', 'media_session_state': 3, 'device': 'hdmi', 'is_volume_muted': False, 'volume': 15}
2019-10-19 20:28:12 INFO (SyncWorker_32) [custom_components.androidtv.media_player] Output of command 'GET_PROPERTIES' from 'media_player.shield': {'screen_on': True, 'awake': True, 'audio_state': 'paused', 'wake_lock_size': 7, 'current_app': 'com.plexapp.android', 'media_session_state': 3, 'device': 'hdmi', 'is_volume_muted': False, 'volume': 15}
2019-10-19 20:28:12 INFO (SyncWorker_22) [custom_components.androidtv.media_player] Output of command 'GET_PROPERTIES' from 'media_player.shield': {'screen_on': True, 'awake': True, 'audio_state': 'paused', 'wake_lock_size': 4, 'current_app': 'com.plexapp.android', 'media_session_state': 3, 'device': 'hdmi', 'is_volume_muted': False, 'volume': 15}
(...)
2019-10-19 20:45:28 INFO (SyncWorker_7) [custom_components.androidtv.media_player] Output of command 'GET_PROPERTIES' from 'media_player.shield': {'screen_on': True, 'awake': True, 'audio_state': 'paused', 'wake_lock_size': 5, 'current_app': 'com.plexapp.android', 'media_session_state': 3, 'device': 'hdmi', 'is_volume_muted': False, 'volume': 15}
```

Since `paused` only uses a `'wake_lock_size': 1`, it seems appropriate to make that the base case, and then the `if else` case for `media_session_state: 3` will always be `playing` (since we aren't sure if the `wake_lock_size` is _only_ limited to  `3`, `4`, `5`, and `7`).

This PR makes those changes to get plex working again (and removing a bunch of the edge cases I kept experiencing).