### PR TITLE
Plex fix

### DIFF
--- a/custom_components/androidtv/androidtv/firetv.py
+++ b/custom_components/androidtv/androidtv/firetv.py
@@ -181,6 +181,16 @@ class FireTV(BaseTV):
                 else:
                     state = constants.STATE_STANDBY
 
+            # Plex
+            elif current_app == constants.APP_PLEX:
+                if media_session_state == 3:
+                    if wake_lock_size == 2:
+                        state = constants.STATE_PAUSED
+                    else:
+                        state = constants.STATE_PLAYING
+                else:
+                    state = constants.STATE_STANDBY
+
             # Sport 1
             elif current_app == constants.APP_SPORT1:
                 if wake_lock_size == 2:


### PR DESCRIPTION
For me this seems to work fine since my light-dimming automation is based on the state and I recognize no light changes while watching.
However this leaves Amazon Video broken, since there I have a lot light changes while watching. Haven't had time to debug that further.