### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/androidtv/manifest.json
+++ b/custom_components/androidtv/manifest.json
@@ -2,6 +2,7 @@
   "domain": "androidtv",
   "name": "Android TV",
   "documentation": "https://www.home-assistant.io/integrations/androidtv",
+  "version": "1.2.2",
   "requirements": [
     "adb-shell[async]==0.2.1",
     "androidtv[async]==0.0.47",


### PR DESCRIPTION
Add a version for future home assistant requirement and stop the error message in the log.
```
No 'version' key in the manifest file for custom integration 'androidtv'. As of Home Assistant 2021.6, this integration will no longer be loaded. Please report this to the maintainer of 'androidtv'
```